### PR TITLE
#167342290 Build and test and endpoint that updates a trips's status

### DIFF
--- a/api/src/auth/bookings.js
+++ b/api/src/auth/bookings.js
@@ -7,8 +7,10 @@ import { TripQueries } from '../helpers/queries';
 export default class Bookings {
   static async verifyTrip(req, res, next) {
     const { trip_id } = req.body;
+    const { tripId } = req.params;
+    const tripIdNo = tripId || trip_id;
     const findTripQuery = TripQueries.findTripById();
-    this.findTrip = await database.queryOneORNone(findTripQuery, [trip_id]);
+    this.findTrip = await database.queryOneORNone(findTripQuery, [tripIdNo]);
     if (!this.findTrip) protocol.err404Res(res, TitledErrors.dataNotFound('Trip data'));
     else next();
   }

--- a/api/src/auth/trips.js
+++ b/api/src/auth/trips.js
@@ -3,6 +3,7 @@ import protocol from '../helpers/response';
 import database from '../db/pgConnect';
 import { UntitledErrors, TitledErrors } from '../helpers/errors';
 import { TripQueries, BusQueries } from '../helpers/queries';
+import authenticatedTrip from './bookings';
 
 export default class {
   static async verifyBus(req, res, next) {
@@ -22,5 +23,15 @@ export default class {
       [bus_id, trip_date]);
     if (findTripsByBusId) return protocol.err400Res(res, UntitledErrors.tripDateScheduleErr());
     return next();
+  }
+
+  static verifyTripStatus(req, res, next) {
+    const { verifyTrip } = authenticatedTrip;
+    const { status } = req.body;
+    if (status !== 'Active' && status !== 'Cancelled'
+      && status !== 'active' && status !== 'cancelled') protocol.err400Res(res, UntitledErrors.statusError());
+    // eslint-disable-next-line max-len
+    else if (status === verifyTrip.status) protocol.err400Res(res, TitledErrors.statusUpdateErr(status));
+    else next();
   }
 }

--- a/api/src/auth/trips.js
+++ b/api/src/auth/trips.js
@@ -4,6 +4,7 @@ import database from '../db/pgConnect';
 import { UntitledErrors, TitledErrors } from '../helpers/errors';
 import { TripQueries, BusQueries } from '../helpers/queries';
 import authenticatedTrip from './bookings';
+import checkRequest from '../helpers/requests';
 
 export default class {
   static async verifyBus(req, res, next) {
@@ -28,8 +29,8 @@ export default class {
   static verifyTripStatus(req, res, next) {
     const { verifyTrip } = authenticatedTrip;
     const { status } = req.body;
-    if (status !== 'Active' && status !== 'Cancelled'
-      && status !== 'active' && status !== 'cancelled') protocol.err400Res(res, UntitledErrors.statusError());
+    const checkStatus = checkRequest.checkValue(status, UntitledErrors.statusError(), 'Active', 'Cancelled', 'active', 'cancelled');
+    if (checkStatus) protocol.err400Res(res, checkStatus);
     // eslint-disable-next-line max-len
     else if (status === verifyTrip.status) protocol.err400Res(res, TitledErrors.statusUpdateErr(status));
     else next();

--- a/api/src/controllers/trips.js
+++ b/api/src/controllers/trips.js
@@ -33,4 +33,12 @@ export default class Trips {
     const allTripsRes = await models.tripDataArray(allTrips);
     return protocol.success200Res(res, allTripsRes);
   }
+
+  static async updateStatus(req, res) {
+    const { tripId } = req.params;
+    const { status } = req.body;
+    const updateStatusQuery = TripQueries.updateTripById();
+    await database.queryNone(updateStatusQuery, [status, tripId]);
+    return protocol.success200ResMessage(res, `Trip status successfully updated to ${status.toLowerCase()}`);
+  }
 }

--- a/api/src/data/trips.js
+++ b/api/src/data/trips.js
@@ -17,4 +17,14 @@ export default class Trips {
     if (findErr) protocol.err400Res(res, findErr);
     else next();
   }
+
+  static updateStatus(req, res, next) {
+    const { tripId } = req.params;
+    const { status } = req.body;
+    const tripIdErr = checkRequest.validateInteger(tripId, 'Trip id');
+    const statusErr = checkRequest.validateLetters(status, 'Trip status');
+    const findErr = checkRequest.findError(tripIdErr, statusErr);
+    if (findErr) protocol.err400Res(res, findErr);
+    else next();
+  }
 }

--- a/api/src/helpers/errors.js
+++ b/api/src/helpers/errors.js
@@ -39,6 +39,10 @@ class TitledErrors {
   static dataFound(title) {
     return `${title} already exists`;
   }
+
+  static statusUpdateErr(title) {
+    return `Status is already ${title.toLowerCase()}`;
+  }
 }
 
 
@@ -97,6 +101,10 @@ class UntitledErrors {
 
   static notNumberPlate() {
     return 'Number plate must be capital letters and positive integers of exactly 8 characters';
+  }
+
+  static statusError() {
+    return 'Status must be active or cancelled';
   }
 }
 

--- a/api/src/helpers/queries.js
+++ b/api/src/helpers/queries.js
@@ -14,6 +14,10 @@ class TripQueries {
   static findTripById() {
     return 'SELECT * FROM trips WHERE id = $1';
   }
+
+  static updateTripById() {
+    return 'UPDATE trips SET status = $1 WHERE id = $2';
+  }
 }
 
 class UserQueries {

--- a/api/src/middleware/trips.js
+++ b/api/src/middleware/trips.js
@@ -2,18 +2,26 @@ import authenticateUsers from '../auth/users';
 import middleware from './middleware';
 import validateTripData from '../data/trips';
 import authenticateTrip from '../auth/trips';
+import authenticateMoreTripData from '../auth/bookings';
 
 export default class Trips {
   static create() {
     const validate = validateTripData.create.bind(validateTripData);
     this.authAll = authenticateUsers.authenticateAll.bind(authenticateUsers);
-    const authAdmin = authenticateUsers.admin.bind(authenticateUsers);
+    this.authAdmin = authenticateUsers.admin.bind(authenticateUsers);
     const authBus = authenticateTrip.verifyBus.bind(authenticateTrip);
     const authTripDate = authenticateTrip.verifyTripDate.bind(authenticateTrip);
-    return middleware.routeCallbacks(validate, this.authAll, authAdmin, authBus, authTripDate);
+    return middleware.routeCallbacks(validate, this.authAll, this.authAdmin, authBus, authTripDate);
   }
 
   static getAll() {
     return middleware.routeCallbacks(this.authAll);
+  }
+
+  static updateStatus() {
+    const validate = validateTripData.updateStatus.bind(validateTripData);
+    const authTrip = authenticateMoreTripData.verifyTrip.bind(authenticateMoreTripData);
+    const authStatus = authenticateTrip.verifyTripStatus.bind(authenticateTrip);
+    return middleware.routeCallbacks(validate, this.authAll, this.authAdmin, authTrip, authStatus);
   }
 }

--- a/api/src/routes/trips.js
+++ b/api/src/routes/trips.js
@@ -7,5 +7,6 @@ router.post('/trips', tripMiddleware.create(), tripController.create.bind(tripCo
 
 router.get('/trips', tripMiddleware.getAll(), tripController.getAll.bind(tripController));
 
+router.patch('/trips/:tripId', tripMiddleware.updateStatus(), tripController.updateStatus.bind(tripController));
 
 export default router;

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,7 @@ require('./trips/createOne');
 require('./trips/getAll');
 require('./bookings/createOne');
 require('./bookings/getAll');
+require('./trips/updateStatus');
 
 export {
   expect,

--- a/test/trips/updateStatus.js
+++ b/test/trips/updateStatus.js
@@ -1,0 +1,248 @@
+import Test, {
+  expect,
+  chai,
+  chaiHttp,
+  app,
+  pool,
+} from '../test';
+
+chai.use(chaiHttp);
+
+describe('Test endpoint at "/api/v1/trips/:tripId" to update a trip status as an authenticated Admin with PATCH', () => {
+  before(async () => {
+    await pool.queryNone(Test.deleteData());
+  });
+
+  before(async () => {
+    await pool.queryAny(Test.users());
+  });
+
+  before(async () => {
+    await pool.queryAny(Test.buses());
+  });
+
+  before(async () => {
+    await pool.queryAny(Test.trips());
+  });
+
+
+  before(async () => {
+    await pool.queryAny(Test.bookings());
+  });
+
+  after(async () => {
+    await pool.queryNone(Test.deleteData());
+  });
+
+  it('Should update a trip status "/api/v1/trips/:tripId" as an authenticated Admin if all input data are valid', async () => {
+    const tripId = 3030303030303;
+    const token = await Test.generateToken('5050505050505');
+    const status = 'Cancelled';
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(200);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(200);
+    expect(response.body).to.have.property('message').to.be.a('string').to.equal(`Trip status successfully updated to ${status.toLowerCase()}`);
+  });
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if status is not a string type', async () => {
+    const tripId = 3030303030303;
+    const token = await Test.generateToken('5050505050505');
+    const status = 1000;
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Trip status must be string type');
+  });
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if status is an empty string', async () => {
+    const tripId = 3030303030303;
+    const token = await Test.generateToken('5050505050505');
+    const status = '';
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Trip status is required');
+  });
+
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if status is undefined', async () => {
+    const tripId = 3030303030303;
+    const token = await Test.generateToken('5050505050505');
+    const status = undefined;
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Trip status is required');
+  });
+
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if status is null', async () => {
+    const tripId = 3030303030303;
+    const token = await Test.generateToken('5050505050505');
+    const status = null;
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Trip status is required');
+  });
+
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if status is not sent', async () => {
+    const tripId = 3030303030303;
+    const token = await Test.generateToken('5050505050505');
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token);
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Trip status is required');
+  });
+
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if status does not equal active or cancelled (capitalized insensitive)', async () => {
+    const tripId = 3030303030303;
+    const token = await Test.generateToken('5050505050505');
+    const status = 'leeeeemaooooo';
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Status must be active or cancelled');
+  });
+
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if status is an empty string', async () => {
+    const tripId = 3030303030303;
+    const token = await Test.generateToken('5050505050505');
+    const status = '';
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Trip status is required');
+  });
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if trip id is not a number', async () => {
+    const tripId = 'hahahahaha';
+    const token = await Test.generateToken('5050505050505');
+    const status = 'Cancelled';
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Trip id must be a positive integer');
+  });
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if trip id is a negative integer', async () => {
+    const tripId = -3030303030303;
+    const token = await Test.generateToken('5050505050505');
+    const status = 'Cancelled';
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Trip id must be a positive integer');
+  });
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if trip id is a negative floating point number', async () => {
+    const tripId = -303030.3030303;
+    const token = await Test.generateToken('5050505050505');
+    const status = 'Cancelled';
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Trip id must be a positive integer');
+  });
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if trip id is a floating point number', async () => {
+    const tripId = 303030.3030303;
+    const token = await Test.generateToken('5050505050505');
+    const status = 'Cancelled';
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Trip id must be a positive integer');
+  });
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if token is an empty string', async () => {
+    const tripId = 3030303030303;
+    const token = '';
+    const status = 'Cancelled';
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Token is required, please sign in or sign up');
+  });
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if token is not sent', async () => {
+    const tripId = 3030303030303;
+    const status = 'Cancelled';
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).send({ status });
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Token is required, please sign in or sign up');
+  });
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if token does not match user', async () => {
+    const tripId = 3030303030303;
+    const token = await Test.generateToken('1010101012020');
+    const status = 'Cancelled';
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(404);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(404);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Token provided does not match any user');
+  });
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if id from token does not belong to admin', async () => {
+    const tripId = 3030303030303;
+    const status = 'Cancelled';
+    const token = await Test.generateToken('1010101010101');
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Only admin can access this resource');
+  });
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if id from token is a negative integer', async () => {
+    const tripId = 3030303030303;
+    const status = 'Cancelled';
+    const token = await Test.generateToken('-5050505050505');
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Id from token is not a positive integer');
+  });
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if id from token is a negative floating point number', async () => {
+    const tripId = 3030303030303;
+    const status = 'Cancelled';
+    const token = await Test.generateToken('-505050.5050505');
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Id from token is not a positive integer');
+  });
+
+  it('Should not update a trip status at "/api/v1/trips/:tripId" as an authenticated Admin if id from token is a floating point number', async () => {
+    const tripId = 3030303030303;
+    const status = 'Cancelled';
+    const token = await Test.generateToken('505050.5050505');
+    const response = await chai.request(app).patch(`/api/v1/trips/${tripId}`).set('token', token).send({ status });
+    expect(response).to.have.status(400);
+    expect(response.body).to.be.an('object');
+    expect(response.body).to.have.property('status').to.be.a('number').to.equal(400);
+    expect(response.body).to.have.property('error').to.be.a('string').to.equal('Id from token is not a positive integer');
+  });
+});


### PR DESCRIPTION
**What this PR does ?**
Have an endpoint that updates a trip's status as an authenticated Admin using a database

**Description of task completed ?**
Build the below working endpoint
`PATCH`   `/api/v1/trips/:tripId`

**How to test this ?**
Clone repo, cd into it, install dependencies,  checkout to branch `t-cancel-trip-167342290` and RUN `npm test` or RUN `npm start` to manually test endpoint at `localhost:3000/api/v1/trips/:tripId` with `POSTMAN`

**Relevant Pivotal story**
#167342290